### PR TITLE
Binded sidebar to card component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,6 @@ function App() {
           <Landing />
         </Route>
         <Route exact path="/playground">
-          <EditSidebar></EditSidebar>
           <Playground test={false} />
         </Route>
       </Switch>

--- a/frontend/src/components/edit/EditSidebar.tsx
+++ b/frontend/src/components/edit/EditSidebar.tsx
@@ -1,9 +1,11 @@
+import React, { useState } from "react";
+import { AnyARecord } from "node:dns";
 import { Image, Form, Button } from "react-bootstrap";
 import styled from "styled-components";
 
 const EditSidebarWrapper = styled.div`
   width: 350px;
-  height: 87.5%;
+  min-height: 87.5%;
   padding: 40px;
 
   border: 0px solid #000000;
@@ -11,7 +13,7 @@ const EditSidebarWrapper = styled.div`
   border-radius: 30px;
 
   box-shadow: 2px 2px 50px rgba(0, 0, 0, 0.2);
-  position: fixed;
+  position: absolute;
 `;
 
 const OuterPad = styled.div`
@@ -20,7 +22,9 @@ const OuterPad = styled.div`
   padding: 20px;
 `;
 
-const EditSidebar = () => {
+const EditSidebar = (props:any) => {
+  const [userInfo, editUserInfo] = useState(props.userInfo)
+
   return (
     <OuterPad>
       <EditSidebarWrapper>
@@ -32,29 +36,29 @@ const EditSidebar = () => {
 
           <Form>
             <Form.Group controlId="name">
-              <Form.Control placeholder="Name" />
+              <Form.Control placeholder="Name" value={userInfo.name} onChange={e => {editUserInfo({...userInfo, name: e.target.value})}} />
             </Form.Group>
 
             <Form.Group controlId="header">
-              <Form.Control placeholder="Header" />
+              <Form.Control placeholder="Header" value={userInfo.header} onChange={e => {editUserInfo({...userInfo, header: e.target.value})}}/>
             </Form.Group>
 
             <br></br>
             <br></br>
 
             <Form.Group controlId="phone">
-              <Form.Control placeholder="Phone Number" />
+              <Form.Control placeholder="Phone Number" value={userInfo.phoneNumber} onChange={e => {editUserInfo({...userInfo, phoneNumber: e.target.value})}}/>
             </Form.Group>
 
             <Form.Group controlId="email">
-              <Form.Control placeholder="Email (Optional)" />
+              <Form.Control placeholder="Email (Optional)" value={userInfo.email} onChange={e => {editUserInfo({...userInfo, email: e.target.value})}}/>
             </Form.Group>
 
             <Form.Group controlId="address">
-              <Form.Control placeholder="Address (Optional)" />
+              <Form.Control placeholder="Address (Optional)" value={userInfo.address} onChange={e => {editUserInfo({...userInfo, address: e.target.value})}}/>
             </Form.Group>
 
-            <Button variant="dark" type="submit" size="lg">
+            <Button onClick={(e) => {e.preventDefault(); props.editUserInfo(userInfo); }} variant="dark" type="submit" size="lg">
               Submit
             </Button>
           </Form>

--- a/frontend/src/containers/Playground.tsx
+++ b/frontend/src/containers/Playground.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import EditButton from "../components/buttons/EditButton";
 import ShareButton from "../components/buttons/ShareButton";
 import MainCard from "../components/cards/MainCard";
+import EditSidebar from "../components/edit/EditSidebar";
 
 interface iPlayground {
   test: false;
@@ -26,21 +27,29 @@ const ButtonGroupWrapper = styled.div`
 
 function Playground(props: iPlayground) {
   const [editMode, setEditMode] = useState(false);
+  const [userInfo, editUserInfo] = useState({
+    name: "Deval Parikh",
+    header: "Software Engineer @ BusiCard",
+    phoneNumber: "123-456-7899",
+    email: "dp@busicard.com",
+    address: "12345 N Tantau Ave, Cupertino, CA 95014"
+  })
   const toggleEditMode = () => {
     setEditMode(!editMode);
   };
   return (
     <div className="App">
       <Wrapper>
+      <EditSidebar userInfo={userInfo} editUserInfo={editUserInfo}></EditSidebar>
         <CenterWrapper>
           <MainCard
             imageURL="https://avatars.githubusercontent.com/u/13604973?v=4"
-            name="Deval Parikh"
-            title="Software Engineer @ BusiCard"
+            name={userInfo.name}
+            title={userInfo.header}
             contactInfo={[
-              "123-456-7899",
-              "dp@busicard.com",
-              "12345 N Tantau Ave, Cupertino, CA 95014",
+              userInfo.phoneNumber,
+              userInfo.email,
+              userInfo.address,
             ]}
             editMode={editMode}
           />


### PR DESCRIPTION
Binded the sidebar to the card component
- Sidebar will be pre-populated with user info that will (probably) be fetched from API endpoint in the parent container
- No safety checks were made, if users input empty info then their card will be empty! 😄 
  - will be updated in the next sprint to handle cold-start users and clumsy users that want to break our UI (with empty strings) 💀
- Moved edit sidebar to playground container for now, we can figure out where to  place it later when displaying an edit page vs a view page